### PR TITLE
Real arithmetic for symmetric real matrices

### DIFF
--- a/src/ArnoldiMethod.jl
+++ b/src/ArnoldiMethod.jl
@@ -6,12 +6,13 @@ using StaticArrays
 using Base: RefValue, OneTo
 
 export partialschur, LM, SR, LR, SI, LI, partialeigen
+export History, GeneralHistory, DetailedHistory
 
 """
     Arnoldi(n, k) → Arnoldi
 
 Pre-allocated Arnoldi relation of the Vₖ₊₁ and Hₖ matrices that satisfy
-A * Vₖ = Vₖ₊₁ * Hₖ, where Vₖ₊₁ is orthonormal of size n × (k+1) and Hₖ upper 
+A * Vₖ = Vₖ₊₁ * Hₖ, where Vₖ₊₁ is orthonormal of size n × (k+1) and Hₖ upper
 Hessenberg of size (k+1) × k. The constructor will just allocate sufficient
 space, but will *not* initialize the first vector of `v₁`. For the latter see
 `reinitialize!`.
@@ -23,7 +24,7 @@ struct Arnoldi{T,TV<:StridedMatrix{T},TH<:StridedMatrix{T}}
     function Arnoldi{T}(matrix_order::Int, krylov_dimension::Int) where {T}
         krylov_dimension <= matrix_order || throw(ArgumentError("Krylov dimension should be less than matrix order."))
         V = Matrix{T}(undef, matrix_order, krylov_dimension + 1)
-        H = zeros(T, krylov_dimension + 1, krylov_dimension)    
+        H = zeros(T, krylov_dimension + 1, krylov_dimension)
         return new{T,typeof(V),typeof(H)}(V, H)
     end
 end
@@ -31,9 +32,9 @@ end
 """
     RitzValues(maxdim) → RitzValues
 
-Convenience wrapper for Ritz values + residual norms and some permutation of 
-these values. The Ritz values are computed from the active part of the 
-Hessenberg matrix `H[active:maxdim,active:maxdim]`. 
+Convenience wrapper for Ritz values + residual norms and some permutation of
+these values. The Ritz values are computed from the active part of the
+Hessenberg matrix `H[active:maxdim,active:maxdim]`.
 
 When computing exact shifts in the implicit restart, we need to reorder the Ritz
 values in some way. For convenience we simply keep track of a permutation `ord`
@@ -58,9 +59,9 @@ end
 
 Holds an orthonormal basis `Q` and a (quasi) upper triangular matrix `R`.
 
-For convenience the eigenvalues that appear on the diagonal of `R` are also 
-listed as `eigenvalues`, which is in particular useful in the case of real 
-matrices with complex eigenvalues. Note that the eigenvalues are always a 
+For convenience the eigenvalues that appear on the diagonal of `R` are also
+listed as `eigenvalues`, which is in particular useful in the case of real
+matrices with complex eigenvalues. Note that the eigenvalues are always a
 complex, even when the matrix `R` is real.
 """
 struct PartialSchur{TQ,TR,Tλ<:Complex}

--- a/src/ArnoldiMethod.jl
+++ b/src/ArnoldiMethod.jl
@@ -47,10 +47,10 @@ struct RitzValues{Tv,Tr}
     ord::Vector{Int}
 
     function RitzValues{T}(maxdim::Int) where {T}
-        λs = Vector{complex(T)}(undef, maxdim)
+        λs = Vector{T}(undef, maxdim)
         rs = Vector{real(T)}(undef, maxdim)
         ord = Vector{Int}(undef, maxdim)
-        return new{complex(T),real(T)}(λs, rs, ord)
+        return new{T,real(T)}(λs, rs, ord)
     end
 end
 
@@ -64,7 +64,7 @@ listed as `eigenvalues`, which is in particular useful in the case of real
 matrices with complex eigenvalues. Note that the eigenvalues are always a
 complex, even when the matrix `R` is real.
 """
-struct PartialSchur{TQ,TR,Tλ<:Complex}
+struct PartialSchur{TQ,TR,Tλ<:Number}
     "Orthonormal matrix"
     Q::TQ
     "Quasi upper triangular matrix"


### PR DESCRIPTION
This PR activates real arithmetic for symmetric real matrices, mostly to have a discussion about it. It seems the package used have the possibility to run in real mode.  (Maybe I understood some design decision.) 

A real symmetric matrix now runs in real arithmetic:
```julia
julia> A = spdiagm(
                  -1 => -1.0*ones(90),
                   0 =>  2.0*ones(100),
                   1 => -1.0*ones(90)
       );
julia> decomp, history = partialschur(A, nev=3, tol=1e-6, which=SR());
julia> decomp
PartialSchur decomposition (Float64) of dimension 3
eigenvalues:
3-element Array{Float64,1}:
 0.001165955267651404
 0.004662461618922161
 0.010485442283810287
```
A real non-symmetric matrix runs in complex arithmetic:
```julia
julia> A[1,2]=3;
julia> decomp, history = partialschur(A, nev=3, tol=1e-6, which=SR());
julia> decomp
PartialSchur decomposition (Complex{Float64}) of dimension 3
eigenvalues:
3-element Array{Complex{Float64},1}:
  0.00120759320587943 - 2.896116048932551e-14im 
 0.004828964124679011 + 7.170923453542044e-14im 
 0.010859888459038968 - 1.0550065320516834e-13im
```

I know it's not type stable. Someone who really needs type stability could still get it with the more advanced `_partialschur` function.