### PR TITLE
Add compat for StaticArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,9 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
+[compat]
+StaticArrays = "0.8, 0.9, 0.10, 0.11, 0.12, 1.0"
+
 [extras]
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
I tested locally StaticArrays 0.8, 0.9, 0.10, 0.11, 0.12, 1.0.  Note that one needs https://github.com/haampie/ArnoldiMethod.jl/pull/99 to pass the tests on Julia v1.2 or later.

https://github.com/JuliaRegistries/General/blob/master/A/ArnoldiMethod/Compat.toml is preventing StaticArrays to upgrade to v1.0 if ArnoldiMethod is installed.